### PR TITLE
Fixes typo in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 This repository is an example on how to test a [Python](https://python.org) project using [Buildkite](https://buildkite.com/) and [pipenv](https://github.com/kennethreitz/pipenv).
 
-Note: this example assumes your Buildkite Agent machine has Python and pipenv already instealled. See the [Python Docker Example](https://github.com/buildkite/python-docker-example) for running your Python project on any agent machine that has only Docker installed.
+Note: this example assumes your Buildkite Agent machine has Python and pipenv already installed. See the [Python Docker Example](https://github.com/buildkite/python-docker-example) for running your Python project on any agent machine that has only Docker installed.
 
 ## How does it work?
 


### PR DESCRIPTION
While reading the Readme.md file I found a typo in the word "installed" which was written as "instealled".